### PR TITLE
Make native flag the default.

### DIFF
--- a/blaze-textual.cabal
+++ b/blaze-textual.cabal
@@ -31,7 +31,7 @@ flag developer
 
 flag native
   description: use slow native code for double conversion
-  default: False
+  default: True
 
 library
   exposed-modules:


### PR DESCRIPTION
Since the currently shipping GHCs will not work with double-conversion when using GHCi or Template Haskell, we should have a default setting that does not break common use cases. When a new GHC is released which avoids these bugs, we can conditionally set the default back to non-native.
