### PR TITLE
Fix build when Show has been split out from Num

### DIFF
--- a/Blaze/Text/Int.hs
+++ b/Blaze/Text/Int.hs
@@ -40,7 +40,7 @@ import GHC.Integer.GMP.Internals
 # define PAIR(a,b) (a,b)
 #endif
 
-integral :: Integral a => a -> Builder
+integral :: (Integral a, Show a) => a -> Builder
 {-# RULES "integral/Int" integral = bounded :: Int -> Builder #-}
 {-# RULES "integral/Int8" integral = bounded :: Int8 -> Builder #-}
 {-# RULES "integral/Int16" integral = bounded :: Int16 -> Builder #-}


### PR DESCRIPTION
`Show` was recently removed as a superclass of `Num`. This fix means that we'll have a redundant `Show` constraint on older version of base where `Show` still is a superclass of `Num`, but that shouldn't hurt. It's possible to instead fix the compilation error using an `#if` on the version of base, but GHC HEAD hasn't bumped the base version number so such a fix would have to wait until the release.
